### PR TITLE
[JITERA-3] Create feature Rate for recipe

### DIFF
--- a/app/controllers/api/rates_controller.rb
+++ b/app/controllers/api/rates_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  class RatesController < Api::BaseController
+    before_action :doorkeeper_authorize!
+    before_action :current_user_authenticate
+
+    def create
+      command = Rates::Create.call(current_user, params)
+
+      return @error_message = command.errors.full_messages unless command.success?
+
+      @rating = command.result
+    end
+  end
+end

--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -65,4 +65,8 @@ class Api::RecipesController < Api::BaseController
     @recipes = results[:recipes]
     @pagy = results[:pagy]
   end
+
+  def rates
+    @pagy, @ratings = pagy(Rating.includes(:rated_by).where(recipe_id: params[:id]))
+  end
 end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,0 +1,23 @@
+class Rating < ApplicationRecord
+  belongs_to :rated_by, foreign_key: 'rated_by', class_name: 'User', inverse_of: :ratings
+
+  belongs_to :recipe
+
+  enum status: {
+    published: 'published',
+    reviewing: 'reviewing',
+    rejected: 'rejected'
+  }
+
+  validates :point, numericality: { in: 1..5 }
+
+  validates :status, presence: true
+
+  validate :rate_to_own_recipe?, if: -> { recipe && rated_by }
+
+  private
+
+  def rate_to_own_recipe?
+    errors.add(:rated_by, I18n.t('errors.cannot_rate_your_own')) if recipe.user_id == rated_by.id
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -6,6 +6,8 @@ class Recipe < ApplicationRecord
 
   has_many :ingredients, dependent: :destroy
 
+  has_many :ratings, dependent: :destroy
+
   belongs_to :category
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   has_many :ingredients, through: :recipes
 
+  has_many :ratings, foreign_key: 'rated_by', dependent: :destroy, inverse_of: :user
+
   # jitera-anchor-dont-touch: enum
 
   # jitera-anchor-dont-touch: file

--- a/app/policies/rate_policy.rb
+++ b/app/policies/rate_policy.rb
@@ -1,0 +1,5 @@
+class RatePolicy < ApplicationPolicy
+  def create?
+    true
+  end
+end

--- a/app/policies/recipe_policy.rb
+++ b/app/policies/recipe_policy.rb
@@ -18,4 +18,8 @@ class RecipePolicy < ApplicationPolicy
   def delete?
     true
   end
+
+  def rates?
+    true
+  end
 end

--- a/app/services/rates/create.rb
+++ b/app/services/rates/create.rb
@@ -1,0 +1,34 @@
+module Rates
+  class Create
+    prepend SimpleCommand
+
+    def initialize(user, params)
+      @rated_by = user
+      @rating_params = rating_params(params)
+    end
+
+    def call
+      rating = Rating.new(
+        rated_by: @rated_by,
+        recipe: recipe,
+        content: @rating_params[:content],
+        point: @rating_params[:point],
+        status: Rating.statuses[:reviewing]
+      )
+
+      return errors.add(:base, rating.errors.messages) unless rating.save
+
+      rating
+    end
+
+    private
+
+    def rating_params(params)
+      params.required('rates').permit(:recipe_id, :content, :point)
+    end
+
+    def recipe
+      @recipe ||= Recipe.find(@rating_params[:recipe_id])
+    end
+  end
+end

--- a/app/views/api/rates/create.json.jbuilder
+++ b/app/views/api/rates/create.json.jbuilder
@@ -1,0 +1,11 @@
+if @rating.present?
+  json.content @rating.content
+  json.point @rating.point
+  json.status @rating.status
+  json.created_at @rating.created_at
+  json.updated_at @rating.updated_at
+  json.rated_by @rating.rated_by
+  json.recipe @rating.recipe
+else
+  json.error_message @error_message
+end

--- a/app/views/api/recipes/rates.json.jbuilder
+++ b/app/views/api/recipes/rates.json.jbuilder
@@ -1,0 +1,6 @@
+if @ratings.present?
+  json.pagination @pagy
+  json.ratings @ratings
+else
+  json.ratings []
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,3 +8,4 @@ en:
     unauthorized_error: Unauthorized
     record_not_uniq_error: Record not uniq
     parameter_missing_error: 'Missing parameters'
+    cannot_rate_your_own: 'You cannot rate your recipe'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,11 @@ resources :categories, only: [:index, :create, :show, :update, :destroy] do
 
     resources :recipes, only: [:index, :create, :show, :update, :destroy] do
       get 'filter', on: :collection
+      get 'rates', on: :member
     end
 
+    resources :rates, only: [:create] do
+    end
   end
 
   # jitera-anchor-dont-touch: webhooks

--- a/db/migrate/20220716025612_create_ratings.rb
+++ b/db/migrate/20220716025612_create_ratings.rb
@@ -1,0 +1,16 @@
+class CreateRatings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ratings do |t|
+      t.integer :rated_by
+      t.integer :recipe_id
+      t.integer :point
+      t.string :content
+      t.string :status
+      t.timestamps
+    end
+
+    add_index :ratings, :rated_by
+    add_index :ratings, :recipe_id
+    add_index :ratings, [:rated_by, :recipe_id], unique: true
+  end
+end

--- a/spec/factories/ratings.rb
+++ b/spec/factories/ratings.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :rating do
+    rated_by { FactoryBot.create(:user) }
+    recipe { FactoryBot.create(:recipe) }
+    point { rand(1..5) }
+    content { Faker::Lorem.paragraph_by_chars(number: rand(0..255)) }
+    status { 'reviewing' }
+  end
+end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Rating, type: :model do
+  let(:rating) do
+    create(:rating)
+  end
+
+  describe 'Assocations' do
+    it { is_expected.to belong_to(:recipe) }
+    it { is_expected.to belong_to(:rated_by) }
+  end
+
+  describe 'Valid subject' do
+    it 'is valid rating' do
+      expect(rating).to be_valid
+    end
+  end
+
+  describe 'Invalid enum validations' do
+    it 'is invalid enum value' do
+      rating = described_class.new
+      expect do
+        rating.status = 'invalid_enum'
+      end.to raise_error(ArgumentError, "'invalid_enum' is not a valid status")
+    end
+  end
+
+  describe 'Validate presence' do
+    it { is_expected.to validate_numericality_of(:point) }
+    it { is_expected.to validate_presence_of(:status) }
+  end
+
+  describe 'Validate rate_to_own_recipe?' do
+    let(:recipe) { create(:recipe) }
+
+    before do
+      rating.recipe = recipe
+      rating.rated_by = recipe.user
+    end
+
+    it 'is invalid' do
+      expect(rating).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/api/recipes_spec.rb
+++ b/spec/requests/api/recipes_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'api/recipes', type: :request do
 
         let(:resource_owner) { create(:user) }
         let(:token) { create(:access_token, resource_owner: resource_owner).token }
-        let(:Authorization) { "Bearer #{token}" }
+        let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
         let(:params) {}
         let(:id) { create(:recipe).id }
 
@@ -173,7 +173,7 @@ RSpec.describe 'api/recipes', type: :request do
 
         let(:resource_owner) { create(:user) }
         let(:token) { create(:access_token, resource_owner: resource_owner).token }
-        let(:Authorization) { "Bearer #{token}" }
+        let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
         let(:id) { create(:recipe).id }
 
         let(:params) {}
@@ -244,7 +244,7 @@ RSpec.describe 'api/recipes', type: :request do
 
         let(:resource_owner) { create(:user) }
         let(:token) { create(:access_token, resource_owner: resource_owner).token }
-        let(:Authorization) { "Bearer #{token}" }
+        let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
         let(:params) {}
         let(:id) { create(:recipe).id }
 
@@ -460,7 +460,46 @@ RSpec.describe 'api/recipes', type: :request do
 
         let(:resource_owner) { create(:user) }
         let(:token) { create(:access_token, resource_owner: resource_owner).token }
-        let(:Authorization) { "Bearer #{token}" }
+        let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
+        let(:params) {}
+        run_test! do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+
+  path '/api/recipes/{id}/rates' do
+    get "List recipe's rates" do
+      tags 'filter'
+      consumes 'application/json'
+      security [bearerAuth: []]
+      parameter name: 'id', in: :path, type: 'string', description: 'id'
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+        }
+      }
+      response '200', 'filter' do
+        examples 'application/json' => {
+          'pagination' => 'integer',
+
+          'ratings' =>
+          [
+            'id' => 'integer',
+            'rated_by' => {
+              'email' => 'string'
+            },
+            'recipe_id' => 'string',
+            'content' => 'string',
+            'point' => 'number'
+          ],
+          'error_message' => 'string'
+        }
+
+        let(:resource_owner) { create(:user) }
+        let(:token) { create(:access_token, resource_owner: resource_owner).token }
+        let(:Authorization) { "Bearer #{token}" } # rubocop:disable RSpec/VariableName
         let(:params) {}
         run_test! do |response|
           expect(response.status).to eq(200)


### PR DESCRIPTION
## Overview
- [x] User can rate the recipe, but cannot rate their own recipe
- [x] Use validation Uniq from MySQL instead of Rails
- [x] Update Rspec - (simple case)
- [x] I create a rates controller separate for the expansion in the future if we want to rate to other types (only recipe for now)


## Issues
Recipes can be rated by other users and should be able to see who has rated them. Design database and implement business logic

## API document 
Will share the Postman + Environments after that

## Loom url